### PR TITLE
[ISSUE-12] post 상세 페이지 

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
-    "next-mdx-remote": "^5.0.0",
+    "next-mdx-remote": "^6.0.0",
     "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 16.1.1
         version: 16.1.1(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-mdx-remote:
-        specifier: ^5.0.0
-        version: 5.0.0(@types/react@19.2.8)(react@19.2.3)
+        specifier: ^6.0.0
+        version: 6.0.0(@types/react@19.2.8)(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1926,8 +1926,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next-mdx-remote@5.0.0:
-    resolution: {integrity: sha512-RNNbqRpK9/dcIFZs/esQhuLA8jANqlH694yqoDBK8hkVdJUndzzGmnPHa2nyi90N4Z9VmzuSWNRpr5ItT3M7xQ==}
+  next-mdx-remote@6.0.0:
+    resolution: {integrity: sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ==}
     engines: {node: '>=14', npm: '>=7'}
     peerDependencies:
       react: '>=16'
@@ -2481,9 +2481,6 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
-  unist-util-is@5.2.1:
-    resolution: {integrity: sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==}
-
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -2493,20 +2490,17 @@ packages:
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
 
-  unist-util-remove@3.1.1:
-    resolution: {integrity: sha512-kfCqZK5YVY5yEa89tvpl7KnBBHu2c6CzMkqHUrlOqaRgGOMp0sMvwWOVrbAtj03KhovQB7i96Gda72v/EFE0vw==}
+  unist-util-remove@4.0.0:
+    resolution: {integrity: sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
 
-  unist-util-visit-parents@5.1.3:
-    resolution: {integrity: sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==}
-
   unist-util-visit-parents@6.0.2:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
 
-  unist-util-visit@5.0.0:
-    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -2911,7 +2905,7 @@ snapshots:
       unified: 11.0.5
       unist-util-position-from-estree: 2.0.0
       unist-util-stringify-position: 4.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -4517,7 +4511,7 @@ snapshots:
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
 
   mdast-util-to-markdown@2.1.2:
@@ -4529,7 +4523,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
   mdast-util-to-string@4.0.0:
@@ -4771,13 +4765,14 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-mdx-remote@5.0.0(@types/react@19.2.8)(react@19.2.3):
+  next-mdx-remote@6.0.0(@types/react@19.2.8)(react@19.2.3):
     dependencies:
       '@babel/code-frame': 7.28.6
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.8)(react@19.2.3)
       react: 19.2.3
-      unist-util-remove: 3.1.1
+      unist-util-remove: 4.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
       vfile-matter: 5.0.1
     transitivePeerDependencies:
@@ -5416,10 +5411,6 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unist-util-is@5.2.1:
-    dependencies:
-      '@types/unist': 2.0.11
-
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -5432,27 +5423,22 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  unist-util-remove@3.1.1:
+  unist-util-remove@4.0.0:
     dependencies:
-      '@types/unist': 2.0.11
-      unist-util-is: 5.2.1
-      unist-util-visit-parents: 5.1.3
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   unist-util-stringify-position@4.0.0:
     dependencies:
       '@types/unist': 3.0.3
-
-  unist-util-visit-parents@5.1.3:
-    dependencies:
-      '@types/unist': 2.0.11
-      unist-util-is: 5.2.1
 
   unist-util-visit-parents@6.0.2:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
 
-  unist-util-visit@5.0.0:
+  unist-util-visit@5.1.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -161,4 +161,9 @@
   pre {
     @apply font-mono;
   }
+
+  h2,
+  h3 {
+    @apply scroll-mt-18;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,7 +58,7 @@ export default function RootLayout({
       <body
         className={cn(
           `${inter.variable} ${notoKr.variable} ${mono.variable} antialiased`,
-          "mx-auto flex h-screen w-full max-w-4xl flex-col p-4",
+          "flex h-screen w-full flex-col",
         )}
       >
         <ThemeProvider>

--- a/src/app/posts/[slug]/layout.tsx
+++ b/src/app/posts/[slug]/layout.tsx
@@ -1,0 +1,16 @@
+import { ReadingProgressBar } from "@/components/ReadingProgressBar";
+import { TocSidebar } from "@/components/TocSideBanner";
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative mx-auto max-w-3xl px-4">
+      <ReadingProgressBar />
+
+      <div className="sticky top-30 h-fit">
+        <TocSidebar />
+      </div>
+
+      {children}
+    </div>
+  );
+}

--- a/src/app/posts/[slug]/layout.tsx
+++ b/src/app/posts/[slug]/layout.tsx
@@ -3,7 +3,7 @@ import { TocSidebar } from "@/components/TocSideBanner";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="relative mx-auto max-w-3xl px-4">
+    <div className="relative mx-auto w-full max-w-3xl px-4">
       <ReadingProgressBar />
 
       <div className="sticky top-30 h-fit">

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import { ReadingProgressBar } from "@/components/ReadingProgressBar";
 import { getPost } from "@/lib/posts";
 import { notFound } from "next/navigation";
 
@@ -15,10 +14,8 @@ export default async function PostPage({
   const { content, readingTime, meta } = post;
 
   return (
-    <>
-      <ReadingProgressBar />
-
-      <div className="my-10 flex flex-col gap-8 border-b border-gray-300 pb-4">
+    <article>
+      <header className="my-10 flex flex-col gap-8 border-b border-gray-300 pb-4">
         <h1 className="text-4xl font-bold">{meta.title}</h1>
 
         <div className="flex items-center gap-2">
@@ -26,9 +23,9 @@ export default async function PostPage({
           <span className="text-sm">・</span>
           <span className="text-sm">{readingTime} min read</span>
         </div>
-      </div>
+      </header>
 
       {content}
-    </>
+    </article>
   );
 }

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -12,7 +12,7 @@ export default async function PostPage({
 
   if (!post) return notFound();
 
-  const { content, meta } = post;
+  const { content, readingTime, meta } = post;
 
   return (
     <>
@@ -20,7 +20,12 @@ export default async function PostPage({
 
       <div className="my-10 flex flex-col gap-8 border-b border-gray-300 pb-4">
         <h1 className="text-4xl font-bold">{meta.title}</h1>
-        <time className="text-sm">{meta.date}</time>
+
+        <div className="flex items-center gap-2">
+          <time className="text-sm">{meta.date}</time>
+          <span className="text-sm">・</span>
+          <span className="text-sm">{readingTime} min read</span>
+        </div>
       </div>
 
       {content}

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { ReadingProgressBar } from "@/components/ReadingProgressBar";
 import { getPost } from "@/lib/posts";
 import { notFound } from "next/navigation";
 
@@ -15,6 +16,8 @@ export default async function PostPage({
 
   return (
     <>
+      <ReadingProgressBar />
+
       <div className="my-10 flex flex-col gap-8 border-b border-gray-300 pb-4">
         <h1 className="text-4xl font-bold">{meta.title}</h1>
         <time className="text-sm">{meta.date}</time>

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -4,7 +4,7 @@ export default async function PostsPage() {
   const posts = await getAllPosts();
 
   return (
-    <>
+    <div className="mx-auto w-full max-w-3xl px-4">
       <div className="flex items-end gap-4 py-10">
         <h1 className="text-4xl font-bold">포스트</h1>
         <span>({posts.length}개)</span>
@@ -24,6 +24,6 @@ export default async function PostsPage() {
           </li>
         ))}
       </ul>
-    </>
+    </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,7 +17,7 @@ export function Header() {
           kimfriendship
         </Link>
 
-        <ul className="ml-auto flex items-center gap-4">
+        <ul className="mr-4 ml-auto flex items-center gap-4">
           {navList.map(({ href, label }) => (
             <li key={href}>
               <Link href={href} className="underline-offset-4 hover:underline">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,10 +8,10 @@ const navList = [
 
 export function Header() {
   return (
-    <header className="bg-background/80 fixed top-0 left-0 w-full shadow-xs backdrop-blur-md">
+    <header className="bg-background/80 fixed top-0 left-0 z-10 w-full shadow-xs backdrop-blur-md">
       <nav
         aria-label="Primary Navigation"
-        className="mx-auto flex w-full max-w-4xl items-center p-4"
+        className="mx-auto flex w-full max-w-3xl items-center p-4"
       >
         <Link href="/" className="text-xl font-bold">
           kimfriendship

--- a/src/components/ReadingProgressBar.tsx
+++ b/src/components/ReadingProgressBar.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useReadingProgress } from "@/hooks/useReadingProgress";
+
+export function ReadingProgressBar() {
+  const progress = useReadingProgress();
+
+  return (
+    <div className="bg-secondary fixed top-0 left-0 z-10 h-1 w-full">
+      <div
+        className="bg-primary h-1 transition-all duration-200 ease-out"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  );
+}

--- a/src/components/ThemeToggleButton.tsx
+++ b/src/components/ThemeToggleButton.tsx
@@ -14,7 +14,7 @@ export function ThemeToggleButton() {
   return (
     <button
       aria-label="Theme Toggle"
-      className="hover:bg-secondary/20 mx-4 cursor-pointer rounded-md p-2 transition-colors transition-transform duration-300"
+      className="hover:bg-secondary/20 cursor-pointer rounded-md p-2 transition-colors transition-transform duration-300"
       onClick={handleToggle}
     >
       {theme === "light" ? <SunIcon /> : <MoonIcon />}

--- a/src/components/TocSideBanner.tsx
+++ b/src/components/TocSideBanner.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { extractHeadings } from "../lib/extractHeadings";
+import { useActiveHeading } from "../hooks/useActiveHeading";
+import { TocItem } from "@/types/post";
+import { cn } from "@/lib/utils";
+
+export function TocSidebar() {
+  const [tocList, setTocList] = useState<TocItem[]>([]);
+  const articleRef = useRef<HTMLElement | null>(null);
+
+  const activeId = useActiveHeading(tocList);
+
+  useEffect(() => {
+    const article = document.querySelector("article");
+    if (!article) return;
+
+    articleRef.current = article;
+    const toc = extractHeadings(article);
+
+    // eslint-disable-next-line
+    setTocList(toc);
+  }, []);
+
+  if (!tocList.length) return null;
+
+  return (
+    <aside className="absolute left-full ml-16 hidden h-fit w-64 shrink-0 2xl:block">
+      <nav className="border-l border-gray-300 p-4">
+        <span className="mb-2 inline-block font-medium text-gray-500">
+          목차
+        </span>
+
+        <ul className="space-y-1">
+          {tocList.map((item) => (
+            <li key={item.id} className={cn({ "pl-4": item.level === 3 })}>
+              <a
+                href={`#${item.id}`}
+                className={cn(
+                  "block text-sm transition-colors",
+                  activeId === item.id
+                    ? "text-primary font-medium"
+                    : "text-gray-500 hover:text-gray-900",
+                )}
+              >
+                {item.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/src/content/test.mdx
+++ b/src/content/test.mdx
@@ -7,19 +7,22 @@ thumbnail: "/images/posts/next-blog.png"
 slug: creating-next-js-blog
 ---
 
-# 안녕하세요 👋
+## 안녕하세요 👋
 
 이건 **MDX로 만든 첫 블로그 글**입니다.
 
 nce the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
 
-Why do we use it?
+### Why do we use it?
+
 It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).
 
-Where does it come from?
+### Where does it come from?
+
 Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of "de Finibus Bonorum et Malorum" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum dolor sit amet..", comes from a line in section 1.10.32.
 
 The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from "de Finibus Bonorum et Malorum" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.
 
-Where can I get some?
+### Where can I get some?
+
 There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum generators on the Internet tend to repeat predefined chunks as necessary, making this the first true generator on the Internet. It uses a dictionary of over 200 Latin words, combined with a handful of model sentence structures, to generate Lorem Ipsum which looks reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected humour, or non-characteristic words etc.

--- a/src/hooks/useActiveHeading.ts
+++ b/src/hooks/useActiveHeading.ts
@@ -1,0 +1,35 @@
+import { TocItem } from "@/types/post";
+import { useEffect, useState } from "react";
+
+export function useActiveHeading(items: TocItem[]) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!items.length) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+
+        if (visible) {
+          setActiveId(visible.target.id);
+        }
+      },
+      {
+        rootMargin: "-80px 0px -60% 0px",
+        threshold: [0.1, 0.5, 1],
+      },
+    );
+
+    items.forEach((item) => {
+      const el = document.getElementById(item.id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, [items]);
+
+  return activeId;
+}

--- a/src/hooks/useReadingProgress.ts
+++ b/src/hooks/useReadingProgress.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export const useReadingProgress = (): number => {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const current = window.scrollY;
+      const total = document.body.scrollHeight - window.innerHeight;
+      const scrolled = (current / total) * 100;
+      setProgress(scrolled);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return progress;
+};

--- a/src/lib/extractHeadings.ts
+++ b/src/lib/extractHeadings.ts
@@ -1,0 +1,28 @@
+import { TocItem } from "@/types/post";
+
+function slugify(text: string) {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w가-힣\s-]/g, "")
+    .replace(/\s+/g, "-");
+}
+
+export function extractHeadings(container: HTMLElement): TocItem[] {
+  const headings = Array.from(
+    container.querySelectorAll("h2, h3"),
+  ) as HTMLHeadingElement[];
+
+  return headings.map((el) => {
+    const text = el.textContent || "";
+    const id = slugify(text);
+
+    el.id = id; // DOM에 ID 부여
+
+    return {
+      id,
+      text,
+      level: el.tagName === "H2" ? 2 : 3,
+    };
+  });
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import matter from "gray-matter";
 import { compileMDX } from "next-mdx-remote/rsc";
 import path from "path";
+import { calculateReadingTime } from "./readingTime";
 
 // MDX 파일들이 있는 실제 폴더 경로
 const POSTS_PATH = path.join(process.cwd(), "src/content");
@@ -15,6 +16,8 @@ export async function getPost(slug: string) {
 
     const { content: mdxSource, data } = matter(fileSource);
 
+    const reading = calculateReadingTime(mdxSource);
+
     const { content } = await compileMDX({
       source: mdxSource,
       options: {
@@ -24,6 +27,7 @@ export async function getPost(slug: string) {
 
     return {
       content,
+      readingTime: reading.minutes,
       meta: data,
     };
   } catch (e) {

--- a/src/lib/readingTime.ts
+++ b/src/lib/readingTime.ts
@@ -1,0 +1,33 @@
+const WORDS_PER_MINUTE = 200;
+const KOREAN_CHARS_PER_MINUTE = 400;
+
+function cleanMDX(text: string) {
+  return text
+    .replace(/```[\s\S]*?```/g, "") // 코드블록 제거
+    .replace(/`.*?`/g, "") // 인라인 코드 제거
+    .replace(/<[^>]+>/g, "") // JSX/HTML 제거
+    .replace(/[#>*_\-\[\]]/g, "") // 마크다운 기호 제거
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function calculateReadingTime(source: string) {
+  const text = cleanMDX(source);
+
+  const words = text.split(" ").filter(Boolean).length;
+  const chars = text.length;
+
+  const minutesByWords = words / WORDS_PER_MINUTE;
+  const minutesByChars = chars / KOREAN_CHARS_PER_MINUTE;
+
+  const minutes = Math.max(
+    1,
+    Math.ceil(Math.max(minutesByWords, minutesByChars)),
+  );
+
+  return {
+    minutes,
+    words,
+    chars,
+  };
+}

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -6,3 +6,9 @@ export interface PostMeta {
   thumbnail?: string;
   slug: string;
 }
+
+export interface TocItem {
+  id: string;
+  text: string;
+  level: 2 | 3;
+}


### PR DESCRIPTION
# Resolve #12 #13 #14 #15 #16

## 📌 개요
블로그 포스트 상세 페이지 UI/UX를 개선하고, 콘텐츠 가독성과 탐색성을 높이기 위한 기능들을 추가했습니다.  
읽기 진행 상태 표시, 예상 읽기 시간 표시, 목차(TOC) 자동 생성 및 활성화 로직을 구현하여 사용자 경험을 강화했습니다.



## ✨ 변경 사항

### 📝 콘텐츠 UX 개선
- **Reading Progress Bar 추가**
  - 스크롤 위치에 따라 읽기 진행 상태를 상단에 시각적으로 표시

- **Reading Time 계산 및 표시**
  - 글 길이에 기반한 예상 읽기 시간을 자동 계산하여 포스트 상단에 노출


### 📑 목차(TOC) 기능 구현
- **목차 항목 자동 추출 로직 구현**
  - MDX의 h2/h3 heading을 기반으로 TOC 데이터 생성

- **Scroll Spy 훅 추가**
  - 현재 읽고 있는 섹션에 따라 TOC 항목 활성화

- **사이드바 TOC 컴포넌트 구현**
  - 데스크톱 환경에서 sticky 형태로 표시되는 목차 UI 추가


### 🎨 레이아웃 및 스타일 개선
- 포스트 상세 페이지 레이아웃 구조 개선
- 헤더 및 내비게이션 스타일 수정
- 테마 토글 버튼 스타일 정리
- TOC와 본문 간 간격 및 정렬 로직 개선


### 🛠️ 스크롤 UX 개선
- h2/h3 요소에 `scroll-margin-top` 적용
  - 앵커 이동 시 sticky 헤더에 제목이 가려지는 문제 해결


### 🔧 기타
- `next-mdx-remote` 패키지 버전 업데이트


## 🧪 테스트 / 확인 방법

1. 포스트 상세 페이지 진입
2. 다음 항목 정상 동작 확인

- [ ] 예상 읽기 시간이 정확히 표시되는지
- [ ] 상단 reading progress bar가 스크롤에 따라 정상 동작하는지
- [ ] TOC 항목 클릭 시 해당 섹션으로 정확히 이동하는지
- [ ] 스크롤 시 현재 섹션에 맞게 TOC 활성 상태가 변경되는지
- [ ] 헤더에 가려지지 않고 제목이 정상적으로 보이는지
- [ ] 데스크톱에서 TOC가 sticky로 유지되는지


## ⚠️ 참고 사항

- TOC는 h2/h3 기준으로 생성되며, 모바일에서는 표시되지 않습니다.
- `scroll-margin-top` 값을 통해 sticky 헤더 환경에서도 앵커 이동 UX를 개선했습니다.
- Reading progress bar는 window scroll 이벤트 기반으로 동작합니다.
